### PR TITLE
Switch to using ctypes.stubs instead of ctypes.foreign on Windows

### DIFF
--- a/directories.opam
+++ b/directories.opam
@@ -12,7 +12,6 @@ bug-reports: "https://github.com/ocamlpro/directories/issues"
 depends: [
   "dune" {>= "2.1"}
   "ocaml" {>= "4.07.0"}
-  "ctypes-foreign" {>= "0.4.0" & (os = "win32" | os = "cygwin")}
   "ctypes" {>= "0.17.1" & (os = "win32" | os = "cygwin")}
 ]
 build: [

--- a/src/dune
+++ b/src/dune
@@ -4,7 +4,7 @@ open Jbuild_plugin.V1
 
 let os, libs =
   match List.assoc "os_type" ocamlc_config with
-  | "Win32" -> "windows", "ctypes ctypes.foreign"
+  | "Win32" -> "windows", "ctypes ctypes.stubs win_types win_functions"
   | _os -> begin match List.assoc "system" ocamlc_config with
     | "linux" -> "linux", "unix"
     | "macosx" -> "macos", "unix"

--- a/src/windows/bindings/dune
+++ b/src/windows/bindings/dune
@@ -1,0 +1,55 @@
+(* -*- tuareg -*- *)
+
+open Jbuild_plugin.V1
+
+let is_windows =
+  match List.assoc "os_type" ocamlc_config with
+  | "Win32" -> true
+  | _os -> false
+
+let () =
+  if not is_windows then
+    Printf.ksprintf send ""
+  else
+    Printf.ksprintf send "%s"
+    {|
+
+(library
+ (name win_types)
+ (public_name directories.win_types)
+ (modules win_types)
+ (libraries ctypes)
+ (wrapped false))
+
+(library
+ (name win_functions_functor)
+ (public_name directories.win_functions_functor)
+ (modules win_functions_functor)
+ (libraries win_types ctypes ctypes.stubs)
+ (wrapped false))
+
+(executable
+ (name gen_functions)
+ (modules gen_functions)
+ (libraries win_functions_functor ctypes ctypes.stubs))
+
+(rule
+ (target win_functions_c_stubs.c)
+ (deps gen_functions.exe)
+ (action (with-stdout-to %{target} (run %{deps} c))))
+
+(rule
+ (target win_functions_stubs.ml)
+ (deps gen_functions.exe)
+ (action (with-stdout-to %{target} (run %{deps} ml))))
+
+(library
+ (name win_functions)
+ (public_name directories.win_functions)
+ (modules win_functions_stubs win_functions)
+ (libraries win_functions_functor win_types ctypes ctypes.stubs)
+ (foreign_stubs (language c) (names win_functions_c_stubs))
+ (c_library_flags (:standard -lkernel32 -lshell32))
+ (wrapped false))
+ 
+|}

--- a/src/windows/bindings/gen_functions.ml
+++ b/src/windows/bindings/gen_functions.ml
@@ -1,0 +1,29 @@
+
+let print_defines fmt =
+  List.iter (fun (d, v) -> Format.fprintf fmt "#define %s (%s)@\n" d v)
+
+let print_headers fmt =
+  List.iter (Format.fprintf fmt "#include <%s>@\n")
+
+let make_functions_stubs
+    (c_defines : (string * string) list)
+    (c_headers : string list)
+    (functions_functor : (module Cstubs.BINDINGS)) =
+  let fmt = Format.std_formatter in
+  begin
+    match Sys.argv.(1) with
+    | "c" ->
+		print_defines fmt c_defines;
+        print_headers fmt c_headers;
+        Cstubs.write_c ~prefix:"win_stub" fmt functions_functor
+    | "ml" ->
+        Cstubs.write_ml ~prefix:"win_stub" fmt functions_functor
+    | s -> failwith ("unknown functions " ^ s)
+  end;
+  Format.pp_print_flush fmt ()
+
+let () =
+  make_functions_stubs
+    [ "NTDDI_VERSION", "NTDDI_VISTA" ]
+    [ "windows.h"; "shlobj.h" ]
+    (module Win_functions_functor.Apply)

--- a/src/windows/bindings/win_functions.ml
+++ b/src/windows/bindings/win_functions.ml
@@ -1,0 +1,2 @@
+
+include Win_functions_functor.Apply(Win_functions_stubs)

--- a/src/windows/bindings/win_functions_functor.ml
+++ b/src/windows/bindings/win_functions_functor.ml
@@ -1,0 +1,44 @@
+
+module Apply (F : Cstubs.FOREIGN) = struct
+
+  open Ctypes
+  open F
+  open Win_types
+  
+  module Kernel32 = struct
+  
+  (** see
+      https://docs.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte *)
+
+    let wide_char_to_multi_byte =
+      foreign "WideCharToMultiByte" (
+        UINT.t @->        (* UINT   CodePage *)
+        DWORD.t @->       (* DWORD  dwFlags *)
+        LPWCH.t @->       (* LPCWCH lpWideCharStr *)
+        Int.t @->         (* int    cchWideChar *)
+        LPSTR.t @->       (* LPSTR  lpMultiByteStr *)
+        Int.t @->         (* int    cbMultiByte *)
+        LPCH.t @->        (* LPCCH  lpDefaultChar *)
+        LPBOOL.t @->      (* LPBOOL lpUsedDefaultChar *)
+        returning Int.t   (* int *)
+      )
+
+  end
+  
+  module Shell32 = struct
+
+  (** see
+      https://docs.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetknownfolderpath *)
+
+    let sh_get_known_folder_path =
+      foreign "SHGetKnownFolderPath" (
+        ptr GUID.t @->          (* REFKNOWNFOLDERID rfid     (= GUID * ) *)
+        Known_folder_flag.t @-> (* DWORD            dwFlags  (= unsigned long) *)
+        Token.t @->             (* HANDLE           hToken   (= void * ) *)
+        ptr PWSTR.t @->         (* PWSTR *          ppszPath (= short unsigned int ** ) *)
+        returning Hresult.t     (* HRESULT *)
+      )
+
+  end
+
+end

--- a/src/windows/bindings/win_types.ml
+++ b/src/windows/bindings/win_types.ml
@@ -1,0 +1,272 @@
+
+open Ctypes
+
+module CHAR = struct
+  type t = char typ
+  let t = char
+end
+
+module LPCH = struct
+  type t = CHAR.t ptr typ
+  let t = ptr CHAR.t
+  let null = from_voidp CHAR.t Ctypes.null
+end
+
+module PCH = LPCH
+
+module WCHAR = struct
+  type t = int typ
+  let t = uint16_t
+end
+
+module LPWCH = struct
+  type t = WCHAR.t ptr typ
+  let t = ptr WCHAR.t
+  let null = from_voidp WCHAR.t Ctypes.null
+end
+
+module PWCH = LPWCH
+
+module BOOL = struct
+  type t = bool
+  let of_int32 i = not (Int32.equal Int32.zero i)
+  let to_int32 b = if b then Int32.one else Int32.zero
+  let t = Ctypes.view ~read:of_int32 ~write:to_int32 Ctypes.int32_t
+end
+
+module LPBOOL = struct
+  type t = BOOL.t ptr typ
+  let t = ptr BOOL.t
+  let null = from_voidp BOOL.t Ctypes.null
+end
+
+module PBOOL = LPBOOL
+
+module Int = struct
+  type t = int32 typ
+  let t = int32_t
+end
+
+module UINT = struct
+  type t = int32 typ
+  let t = int32_t
+end
+
+module DWORD = struct
+  type t = int32 typ
+  let t = int32_t
+end
+
+module LPSTR = struct
+  type t = CHAR.t ptr typ
+  let t = ptr CHAR.t
+  let null = from_voidp CHAR.t Ctypes.null
+end
+
+module PSTR = LPSTR
+
+module LPWSTR = struct
+  type t = WCHAR.t ptr typ
+  let t = ptr WCHAR.t
+  let null = from_voidp WCHAR.t Ctypes.null
+end
+
+module PWSTR = LPWSTR
+
+(** see
+    https://docs.microsoft.com/en-us/windows/win32/api/shlobj_core/ne-shlobj_core-known_folder_flag *)
+module Known_folder_flag = struct
+  type t =
+    | Default
+    | Force_app_data_redirection
+    | Return_filter_redirection_target
+    | Force_package_redirection
+    | No_package_redirection
+    | Create
+    | Dont_verify
+    | Dont_unexpand
+    | No_alias
+    | Init
+    | Default_path
+    | Not_parent_relative
+    | Simple_idlist
+    | Alias_only
+
+  let to_int32 = function
+    | Default -> 0x00000000l
+    | Force_app_data_redirection -> 0x00080000l
+    | Return_filter_redirection_target -> 0x00040000l
+    | Force_package_redirection -> 0x00020000l (* replaces Force_appcontainer_redirection *)
+    | No_package_redirection -> 0x00010000l (* replaces No_appcontainer_redirection *)
+    | Create -> 0x00008000l
+    | Dont_verify -> 0x00004000l
+    | Dont_unexpand -> 0x00002000l
+    | No_alias -> 0x00001000l
+    | Init -> 0x00000800l
+    | Default_path -> 0x00000400l
+    | Not_parent_relative -> 0x00000200l
+    | Simple_idlist -> 0x0000000100l
+    | Alias_only -> 0x80000000l
+
+  let of_int32 = function
+    | 0x00000000l -> Default
+    | 0x00080000l -> Force_app_data_redirection
+    | 0x00040000l -> Return_filter_redirection_target
+    | 0x00020000l -> Force_package_redirection (* Force_appcontainer_redirection *)
+    | 0x00010000l -> No_package_redirection (* No_appcontainer_redirection *)
+    | 0x00008000l -> Create
+    | 0x00004000l -> Dont_verify
+    | 0x00002000l -> Dont_unexpand
+    | 0x00001000l -> No_alias
+    | 0x00000800l -> Init
+    | 0x00000400l -> Default_path
+    | 0x00000200l -> Not_parent_relative
+    | 0x00000100l -> Simple_idlist
+    | 0x80000000l -> Alias_only
+    | n ->
+      raise
+      @@ Invalid_argument (Format.sprintf "Known_folder_flag.of_int: %ld" n)
+
+  let t = Ctypes.view ~read:of_int32 ~write:to_int32 Ctypes.int32_t
+end
+
+(** see https://docs.microsoft.com/en-us/windows/win32/secauthz/access-tokens *
+    as we don't want into troubles, we just bind what we might need... *)
+module Token = struct
+  type t =
+    | Default_user
+    | Current_user
+
+  let to_ptr t =
+	let i =
+	  match t with
+	  | Default_user -> -1
+	  | Current_user -> 0
+	in
+	Ctypes.ptr_of_raw_address (Nativeint.of_int i)
+
+  let of_ptr p =
+	match Nativeint.to_int (Ctypes.raw_address_of_ptr p) with
+    | -1 -> Default_user
+    | 0 -> Current_user
+    | n -> raise @@ Invalid_argument (Format.sprintf "Token.of_int: %d" n)
+
+  let t = Ctypes.view ~read:of_ptr ~write:to_ptr (Ctypes.ptr Ctypes.void)
+end
+
+(** see
+    https://docs.microsoft.com/en-us/windows/win32/seccrypto/common-hresult-values *)
+module Hresult = struct
+  type t =
+    | S_ok
+    | E_abort
+    | E_accessdenied
+    | E_fail
+    | E_handle
+    | E_invalid_arg
+    | E_nointerface
+    | E_notimpl
+    | E_outofmemory
+    | E_pointer
+    | E_unexpected
+
+  let to_int32 = function
+    | S_ok ->           0x00000000l
+    | E_abort ->        0x80004004l
+    | E_accessdenied -> 0x80070005l
+    | E_fail ->         0x80004005l
+    | E_handle ->       0x80070006l
+    | E_invalid_arg ->  0x80070057l
+    | E_nointerface ->  0x80004002l
+    | E_notimpl ->      0x80004001l
+    | E_outofmemory ->  0x8007000El
+    | E_pointer ->      0x80004003l
+    | E_unexpected ->   0x8000FFFFl
+
+  let of_int32 (n : Int32.t) =
+    match n with
+    | 0x00000000l -> S_ok
+    | 0x80004004l -> E_abort
+    | 0x80070005l -> E_accessdenied
+    | 0x80004005l -> E_fail
+    | 0x80070006l -> E_handle
+    | 0x80070057l -> E_invalid_arg
+    | 0x80004002l -> E_nointerface
+    | 0x80004001l -> E_notimpl
+    | 0x8007000El -> E_outofmemory
+    | 0x80004003l -> E_pointer
+    | 0x8000FFFFl -> E_unexpected
+    | n ->
+      raise
+      @@ Invalid_argument (Format.sprintf "Hresult.of_int: %x" (Int32.to_int n))
+
+  let t = Ctypes.view ~read:of_int32 ~write:to_int32 Ctypes.int32_t
+end
+
+module GUID = struct
+  type t =
+    | UserProfile
+    | LocalApplicationData
+    | ApplicationData
+    | Music
+    | Desktop
+    | Documents
+    | Downloads
+    | Pictures
+    | Public
+    | Templates
+    | Videos
+
+  (*
+  let to_guid = function
+    | UserProfile          -> 0x5E6C858F, 0x0E22, 0x4760, 0x9A, 0xFE, 0xEA, 0x33, 0x17, 0xB6, 0x71, 0x73
+    | LocalApplicationData -> 0xF1B32785, 0x6FBA, 0x4FCF, 0x9D, 0x55, 0x7B, 0x8E, 0x7F, 0x15, 0x70, 0x91
+    | ApplicationData      -> 0x3EB685DB, 0x65F9, 0x4CF6, 0xA0, 0x3A, 0xE3, 0xEF, 0x65, 0x72, 0x9F, 0x3D
+    | Music                -> 0x4BD8D571, 0x6D19, 0x48D3, 0xBE, 0x97, 0x42, 0x22, 0x20, 0x08, 0x0E, 0x43
+    | Desktop              -> 0xB4BFCC3A, 0xDB2C, 0x424C, 0xB0, 0x29, 0x7F, 0xE9, 0x9A, 0x87, 0xC6, 0x41
+    | Documents            -> 0xFDD39AD0, 0x238F, 0x46AF, 0xAD, 0xB4, 0x6C, 0x85, 0x48, 0x03, 0x69, 0xC7
+    | Downloads            -> 0x374DE290, 0x123F, 0x4565, 0x91, 0x64, 0x39, 0xC4, 0x92, 0x5E, 0x46, 0x7B
+    | Pictures             -> 0x33E28130, 0x4E1E, 0x4676, 0x83, 0x5A, 0x98, 0x39, 0x5C, 0x3B, 0xC3, 0xBB
+    | Public               -> 0xDFDF76A2, 0xC82A, 0x4D63, 0x90, 0x6A, 0x56, 0x44, 0xAC, 0x45, 0x73, 0x85
+    | Templates            -> 0xA63293E8, 0x664E, 0x48DB, 0xA0, 0x79, 0xDF, 0x75, 0x9E, 0x05, 0x09, 0xF7
+    | Videos               -> 0x18989B1D, 0x99B5, 0x455B, 0x84, 0x1C, 0xAB, 0x7C, 0x74, 0xE4, 0xDD, 0xFC
+  *)
+
+  let to_guid = function
+    | UserProfile ->          (0x5E6C858F, 0x0E22, 0x4760, 0x7371B61733EAFE9AL)
+    | LocalApplicationData -> (0xF1B32785, 0x6FBA, 0x4FCF, 0x9170157F8E7B559DL)
+    | ApplicationData ->      (0x3EB685DB, 0x65F9, 0x4CF6, 0x3D9F7265EFE33AA0L)
+    | Music ->                (0x4BD8D571, 0x6D19, 0x48D3, 0x430E0820224297BEL)
+    | Desktop ->              (0xB4BFCC3A, 0xDB2C, 0x424C, 0x41C6879AE97F29B0L)
+    | Documents ->            (0xFDD39AD0, 0x238F, 0x46AF, 0xC7690348856CB4ADL)
+    | Downloads ->            (0x374DE290, 0x123F, 0x4565, 0x7B465E92C4396491L)
+    | Pictures ->             (0x33E28130, 0x4E1E, 0x4676, 0xBBC33B5C39985A83L)
+    | Public ->               (0xDFDF76A2, 0xC82A, 0x4D63, 0x857345AC44566A90L)
+    | Templates ->            (0xA63293E8, 0x664E, 0x48DB, 0xF709059E75DF79A0L)
+    | Videos ->               (0x18989B1D, 0x99B5, 0x455B, 0xFCDDE4747CAB1C84L)
+
+  let t : t structure typ = structure "_GUID"
+
+  let data1 = field t "Data1" ulong
+
+  let data2 = field t "Data2" ushort
+
+  let data3 = field t "Data3" ushort
+
+  (* let data4 = field t "Data4 (array 8 uchar)"*)
+  let data4 = field t "Data4" int64_t
+
+  let () = seal t
+
+  let to_guid guid =
+    (* let d1, d2, d3, d4_0, d4_1, d4_2, d4_3, d4_4, d4_5, d4_6, d4_7 = to_guid guid in *)
+    let d1, d2, d3, d4 = to_guid guid in
+    let guid = make t in
+    setf guid data1 (Unsigned.ULong.of_int d1);
+    setf guid data2 (Unsigned.UShort.of_int d2);
+    setf guid data3 (Unsigned.UShort.of_int d3);
+    setf guid data4 d4;
+    (* let l = [d4_0; d4_1; d4_2; d4_3; d4_4; d4_5; d4_6; d4_7] in
+       setf guid data4 (CArray.map uchar Unsigned.UChar.of_int (CArray.of_list int l)); *)
+    guid
+end

--- a/src/windows/directories.ml
+++ b/src/windows/directories.ml
@@ -1,238 +1,26 @@
 open Ctypes
-open Foreign
 open Common
-
-module Known_folder_flag = struct
-  (** see
-      https://docs.microsoft.com/en-us/windows/win32/api/shlobj_core/ne-shlobj_core-known_folder_flag *)
-  type t =
-    | Default
-    | Force_app_data_redirection
-    | Return_filter_redirection_target
-    | Force_package_redirection
-    | No_package_redirection
-    | Force_appcontainer_redirection
-    | No_appcontainer_redirection
-    | Create
-    | Dont_verify
-    | Dont_unexpand
-    | No_alias
-    | Init
-    | Default_path
-    | Not_parent_relative
-    | Simple_idlist
-    | Alias_only
-
-  let to_int = function
-    | Default -> 0
-    | Force_app_data_redirection -> 1
-    | Return_filter_redirection_target -> 2
-    | Force_package_redirection -> 3
-    | No_package_redirection -> 4
-    | Force_appcontainer_redirection -> 5
-    | No_appcontainer_redirection -> 6
-    | Create -> 7
-    | Dont_verify -> 8
-    | Dont_unexpand -> 9
-    | No_alias -> 10
-    | Init -> 11
-    | Default_path -> 12
-    | Not_parent_relative -> 13
-    | Simple_idlist -> 14
-    | Alias_only -> 15
-
-  let of_int = function
-    | 0 -> Default
-    | 1 -> Force_app_data_redirection
-    | 2 -> Return_filter_redirection_target
-    | 3 -> Force_package_redirection
-    | 4 -> No_package_redirection
-    | 5 -> Force_appcontainer_redirection
-    | 6 -> No_appcontainer_redirection
-    | 7 -> Create
-    | 8 -> Dont_verify
-    | 9 -> Dont_unexpand
-    | 10 -> No_alias
-    | 11 -> Init
-    | 12 -> Default_path
-    | 13 -> Not_parent_relative
-    | 14 -> Simple_idlist
-    | 15 -> Alias_only
-    | n ->
-      raise
-      @@ Invalid_argument (Format.sprintf "Known_folder_flag.of_int: %d" n)
-
-  let t = Ctypes.view ~read:of_int ~write:to_int Ctypes.int
-end
-
-(** see https://docs.microsoft.com/en-us/windows/win32/secauthz/access-tokens *
-    as we don't want into troubles, we just bind what we might need... *)
-module Token = struct
-  type t =
-    | Default_user
-    | Current_user
-
-  let to_int = function
-    | Default_user -> -1
-    | Current_user -> 0
-
-  let of_int = function
-    | -1 -> Default_user
-    | 0 -> Current_user
-    | n -> raise @@ Invalid_argument (Format.sprintf "Token.of_int: %d" n)
-
-  let t = Ctypes.view ~read:of_int ~write:to_int Ctypes.int
-end
-
-(** see
-    https://docs.microsoft.com/en-us/windows/win32/seccrypto/common-hresult-values *)
-module Hresult = struct
-  type t =
-    | S_ok
-    | E_abort
-    | E_accessdenied
-    | E_fail
-    | E_handle
-    | E_invalid_arg
-    | E_nointerface
-    | E_notimpl
-    | E_outofmemory
-    | E_pointer
-    | E_unexpected
-
-  let to_int32 = function
-    | S_ok ->           0x00000000l
-    | E_abort ->        0x80004004l
-    | E_accessdenied -> 0x80070005l
-    | E_fail ->         0x80004005l
-    | E_handle ->       0x80070006l
-    | E_invalid_arg ->  0x80070057l
-    | E_nointerface ->  0x80004002l
-    | E_notimpl ->      0x80004001l
-    | E_outofmemory ->  0x8007000El
-    | E_pointer ->      0x80004003l
-    | E_unexpected ->   0x8000FFFFl
-
-  let of_int32 (n : Int32.t) =
-    match n with
-    | 0x00000000l -> S_ok
-    | 0x80004004l -> E_abort
-    | 0x80070005l -> E_accessdenied
-    | 0x80004005l -> E_fail
-    | 0x80070006l -> E_handle
-    | 0x80070057l -> E_invalid_arg
-    | 0x80004002l -> E_nointerface
-    | 0x80004001l -> E_notimpl
-    | 0x8007000El -> E_outofmemory
-    | 0x80004003l -> E_pointer
-    | 0x8000FFFFl -> E_unexpected
-    | n ->
-      raise
-      @@ Invalid_argument (Format.sprintf "Hresult.of_int: %x" (Int32.to_int n))
-
-  let t = Ctypes.view ~read:of_int32 ~write:to_int32 Ctypes.int32_t
-end
-
-module GUID = struct
-  type t =
-    | UserProfile
-    | LocalApplicationData
-    | ApplicationData
-    | Music
-    | Desktop
-    | Documents
-    | Downloads
-    | Pictures
-    | Public
-    | Templates
-    | Videos
-
-  (*
-  let to_guid = function
-    | UserProfile          -> 0x5E6C858F, 0x0E22, 0x4760, 0x9A, 0xFE, 0xEA, 0x33, 0x17, 0xB6, 0x71, 0x73
-    | LocalApplicationData -> 0xF1B32785, 0x6FBA, 0x4FCF, 0x9D, 0x55, 0x7B, 0x8E, 0x7F, 0x15, 0x70, 0x91
-    | ApplicationData      -> 0x3EB685DB, 0x65F9, 0x4CF6, 0xA0, 0x3A, 0xE3, 0xEF, 0x65, 0x72, 0x9F, 0x3D
-    | Music                -> 0x4BD8D571, 0x6D19, 0x48D3, 0xBE, 0x97, 0x42, 0x22, 0x20, 0x08, 0x0E, 0x43
-    | Desktop              -> 0xB4BFCC3A, 0xDB2C, 0x424C, 0xB0, 0x29, 0x7F, 0xE9, 0x9A, 0x87, 0xC6, 0x41
-    | Documents            -> 0xFDD39AD0, 0x238F, 0x46AF, 0xAD, 0xB4, 0x6C, 0x85, 0x48, 0x03, 0x69, 0xC7
-    | Downloads            -> 0x374DE290, 0x123F, 0x4565, 0x91, 0x64, 0x39, 0xC4, 0x92, 0x5E, 0x46, 0x7B
-    | Pictures             -> 0x33E28130, 0x4E1E, 0x4676, 0x83, 0x5A, 0x98, 0x39, 0x5C, 0x3B, 0xC3, 0xBB
-    | Public               -> 0xDFDF76A2, 0xC82A, 0x4D63, 0x90, 0x6A, 0x56, 0x44, 0xAC, 0x45, 0x73, 0x85
-    | Templates            -> 0xA63293E8, 0x664E, 0x48DB, 0xA0, 0x79, 0xDF, 0x75, 0x9E, 0x05, 0x09, 0xF7
-    | Videos               -> 0x18989B1D, 0x99B5, 0x455B, 0x84, 0x1C, 0xAB, 0x7C, 0x74, 0xE4, 0xDD, 0xFC
-  *)
-
-  let to_guid = function
-    | UserProfile ->          (0x5E6C858F, 0x0E22, 0x4760, 0x7371B61733EAFE9AL)
-    | LocalApplicationData -> (0xF1B32785, 0x6FBA, 0x4FCF, 0x9170157F8E7B559DL)
-    | ApplicationData ->      (0x3EB685DB, 0x65F9, 0x4CF6, 0x3D9F7265EFE33AA0L)
-    | Music ->                (0x4BD8D571, 0x6D19, 0x48D3, 0x430E0820224297BEL)
-    | Desktop ->              (0xB4BFCC3A, 0xDB2C, 0x424C, 0x41C6879AE97F29B0L)
-    | Documents ->            (0xFDD39AD0, 0x238F, 0x46AF, 0xC7690348856CB4ADL)
-    | Downloads ->            (0x374DE290, 0x123F, 0x4565, 0x7B465E92C4396491L)
-    | Pictures ->             (0x33E28130, 0x4E1E, 0x4676, 0xBBC33B5C39985A83L)
-    | Public ->               (0xDFDF76A2, 0xC82A, 0x4D63, 0x857345AC44566A90L)
-    | Templates ->            (0xA63293E8, 0x664E, 0x48DB, 0xF709059E75DF79A0L)
-    | Videos ->               (0x18989B1D, 0x99B5, 0x455B, 0xFCDDE4747CAB1C84L)
-
-  let t : t structure typ = structure "_GUID"
-
-  let data1 = field t "Data1" ulong
-
-  let data2 = field t "Data2" ushort
-
-  let data3 = field t "Data3" ushort
-
-  (* let data4 = field t "Data4 (array 8 uchar)"*)
-  let data4 = field t "Data4" int64_t
-
-  let () = seal t
-
-  let to_guid guid =
-    (* let d1, d2, d3, d4_0, d4_1, d4_2, d4_3, d4_4, d4_5, d4_6, d4_7 = to_guid guid in *)
-    let d1, d2, d3, d4 = to_guid guid in
-    let guid = make t in
-    setf guid data1 (Unsigned.ULong.of_int d1);
-    setf guid data2 (Unsigned.UShort.of_int d2);
-    setf guid data3 (Unsigned.UShort.of_int d3);
-    setf guid data4 d4;
-    (* let l = [d4_0; d4_1; d4_2; d4_3; d4_4; d4_5; d4_6; d4_7] in
-       setf guid data4 (CArray.map uchar Unsigned.UChar.of_int (CArray.of_list int l)); *)
-    guid
-end
-
-(** see
-    https://docs.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte *)
-let wide_char_to_multi_byte =
-  foreign "WideCharToMultiByte"
-    ( int32_t @-> int32_t @-> ptr void @-> int32_t @-> ptr void @-> int32_t
-    @-> ptr void @-> ptr void @-> returning int32_t )
+open Win_types
+open Win_functions
 
 let wstring_to_string wstr =
   let path_len =
-    wide_char_to_multi_byte 65001l 0l wstr (-1l) null 0l null null
+    Kernel32.wide_char_to_multi_byte
+	  65001l 0l wstr (-1l) LPSTR.null 0l LPCH.null LPBOOL.null
   in
-  let path = to_voidp (allocate_n char ~count:(Int32.to_int path_len)) in
+  let path = allocate_n CHAR.t ~count:(Int32.to_int path_len) in
   let _ =
-    wide_char_to_multi_byte 65001l 0l wstr (-1l) path path_len null null
+    Kernel32.wide_char_to_multi_byte
+	  65001l 0l wstr (-1l) path path_len LPCH.null LPBOOL.null
   in
-  coerce (ptr void) string path
-
-(** see
-    https://docs.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetknownfolderpath *)
-let shell32 = Dl.dlopen ~flags:[ Dl.RTLD_LAZY ] ~filename:"SHELL32"
-
-let sh_get_known_folder_path =
-  foreign ~from:shell32 "SHGetKnownFolderPath"
-    ( GUID.t @-> Known_folder_flag.t @-> Token.t
-    @-> ptr (ptr void)
-    @-> returning Hresult.t )
+  coerce LPSTR.t string path
 
 let get_folderid id =
-  let wpath_ptr = allocate (ptr void) null in
+  let wpath_ptr = allocate PWSTR.t PWSTR.null in
   let result =
-    sh_get_known_folder_path (GUID.to_guid id) Known_folder_flag.Default
-      Token.Current_user wpath_ptr
+    Shell32.sh_get_known_folder_path
+	  (addr (GUID.to_guid id)) Known_folder_flag.Default
+	  Token.Current_user wpath_ptr
   in
   match result with
   | S_ok -> Some (wstring_to_string !@wpath_ptr)


### PR DESCRIPTION
This PR switches from using ctypes.foreign to ctypes.stubs in the Windows version.
This is more efficient and avoids depending on libffi.
Fixes #9 .