### PR TITLE
use an array inside the guid struct instead of the int64 trick

### DIFF
--- a/src/windows/bindings/win_types.ml
+++ b/src/windows/bindings/win_types.ml
@@ -1,4 +1,3 @@
-
 open Ctypes
 
 module CHAR = struct
@@ -138,15 +137,15 @@ module Token = struct
     | Current_user
 
   let to_ptr t =
-	let i =
-	  match t with
-	  | Default_user -> -1
-	  | Current_user -> 0
-	in
-	Ctypes.ptr_of_raw_address (Nativeint.of_int i)
+    let i =
+      match t with
+      | Default_user -> -1
+      | Current_user -> 0
+    in
+    Ctypes.ptr_of_raw_address (Nativeint.of_int i)
 
   let of_ptr p =
-	match Nativeint.to_int (Ctypes.raw_address_of_ptr p) with
+    match Nativeint.to_int (Ctypes.raw_address_of_ptr p) with
     | -1 -> Default_user
     | 0 -> Current_user
     | n -> raise @@ Invalid_argument (Format.sprintf "Token.of_int: %d" n)
@@ -217,7 +216,6 @@ module GUID = struct
     | Templates
     | Videos
 
-  (*
   let to_guid = function
     | UserProfile          -> 0x5E6C858F, 0x0E22, 0x4760, 0x9A, 0xFE, 0xEA, 0x33, 0x17, 0xB6, 0x71, 0x73
     | LocalApplicationData -> 0xF1B32785, 0x6FBA, 0x4FCF, 0x9D, 0x55, 0x7B, 0x8E, 0x7F, 0x15, 0x70, 0x91
@@ -230,20 +228,6 @@ module GUID = struct
     | Public               -> 0xDFDF76A2, 0xC82A, 0x4D63, 0x90, 0x6A, 0x56, 0x44, 0xAC, 0x45, 0x73, 0x85
     | Templates            -> 0xA63293E8, 0x664E, 0x48DB, 0xA0, 0x79, 0xDF, 0x75, 0x9E, 0x05, 0x09, 0xF7
     | Videos               -> 0x18989B1D, 0x99B5, 0x455B, 0x84, 0x1C, 0xAB, 0x7C, 0x74, 0xE4, 0xDD, 0xFC
-  *)
-
-  let to_guid = function
-    | UserProfile ->          (0x5E6C858F, 0x0E22, 0x4760, 0x7371B61733EAFE9AL)
-    | LocalApplicationData -> (0xF1B32785, 0x6FBA, 0x4FCF, 0x9170157F8E7B559DL)
-    | ApplicationData ->      (0x3EB685DB, 0x65F9, 0x4CF6, 0x3D9F7265EFE33AA0L)
-    | Music ->                (0x4BD8D571, 0x6D19, 0x48D3, 0x430E0820224297BEL)
-    | Desktop ->              (0xB4BFCC3A, 0xDB2C, 0x424C, 0x41C6879AE97F29B0L)
-    | Documents ->            (0xFDD39AD0, 0x238F, 0x46AF, 0xC7690348856CB4ADL)
-    | Downloads ->            (0x374DE290, 0x123F, 0x4565, 0x7B465E92C4396491L)
-    | Pictures ->             (0x33E28130, 0x4E1E, 0x4676, 0xBBC33B5C39985A83L)
-    | Public ->               (0xDFDF76A2, 0xC82A, 0x4D63, 0x857345AC44566A90L)
-    | Templates ->            (0xA63293E8, 0x664E, 0x48DB, 0xF709059E75DF79A0L)
-    | Videos ->               (0x18989B1D, 0x99B5, 0x455B, 0xFCDDE4747CAB1C84L)
 
   let t : t structure typ = structure "_GUID"
 
@@ -253,20 +237,18 @@ module GUID = struct
 
   let data3 = field t "Data3" ushort
 
-  (* let data4 = field t "Data4 (array 8 uchar)"*)
-  let data4 = field t "Data4" int64_t
+  let data4 = field t "Data4" (array 8 uchar)
 
   let () = seal t
 
   let to_guid guid =
-    (* let d1, d2, d3, d4_0, d4_1, d4_2, d4_3, d4_4, d4_5, d4_6, d4_7 = to_guid guid in *)
-    let d1, d2, d3, d4 = to_guid guid in
+    let d1, d2, d3, d4_0, d4_1, d4_2, d4_3, d4_4, d4_5, d4_6, d4_7 = to_guid guid in
     let guid = make t in
     setf guid data1 (Unsigned.ULong.of_int d1);
     setf guid data2 (Unsigned.UShort.of_int d2);
     setf guid data3 (Unsigned.UShort.of_int d3);
-    setf guid data4 d4;
-    (* let l = [d4_0; d4_1; d4_2; d4_3; d4_4; d4_5; d4_6; d4_7] in
-       setf guid data4 (CArray.map uchar Unsigned.UChar.of_int (CArray.of_list int l)); *)
+    let d4 = [d4_0; d4_1; d4_2; d4_3; d4_4; d4_5; d4_6; d4_7] in
+    let d4 = List.map Unsigned.UChar.of_int d4 in
+    setf guid data4 (CArray.of_list uchar d4);
     guid
 end


### PR DESCRIPTION
Before #10 we had to use an int64 because libffi doesn't supports array members in structures. So we had to reverse the order of the uchars because of the endianness and put all of them in an int64. It was a bit hacky...

With ctypes.stubs we can use a proper array, this is what is done in this PR.

@ddeclerck, @delthas does it look good to you ?